### PR TITLE
chore: add authors file

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -5,6 +5,6 @@ The following people have contributed to this repository:
 * Björn Roy, Mercedes Benz Group AG, https://github.com/giterrific
 * Siegfried Kiermayer, SAP SE, https://github.com/siegfriedk
 * Daniel Miehle, BMW Group AG, https://github.com/danielmiehle
-* Fabian Grün, Mercedes-Benz Tech Innovation GmbH, https://github.com/Fagru3n
+* Fabian Grün, Mercedes-Benz Tech Innovation GmbH, https://github.com/FaGru3n
 
 Please add yourself to this list, if you contribute to the content.

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,10 @@
+# Authors
+
+The following people have contributed to this repository:
+
+* Björn Roy, Mercedes Benz Group AG, https://github.com/giterrific
+* Siegfried Kiermayer, SAP SE, https://github.com/siegfriedk
+* Daniel Miehle, BMW Group AG, https://github.com/danielmiehle
+* Fabian Grün, Mercedes-Benz Tech Innovation GmbH, https://github.com/Fagru3n
+
+Please add yourself to this list, if you contribute to the content.


### PR DESCRIPTION
### Description of this Pull Request
#### What would be change or will be added with this PR?
- add optional authors.md file as stated in https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-01/
#### Why do i want to change this?
- represent the authors and project leads for the community 
#### Additional information
should look like, please check if the company name is written correctly
![image](https://github.com/eclipse-tractusx/community/assets/121097161/1ec7bc7d-b03f-48d8-8909-33be3d735e4c)
